### PR TITLE
Mm 160/fix infinite jobs on callback fail

### DIFF
--- a/constants/Constants.js
+++ b/constants/Constants.js
@@ -220,5 +220,10 @@ module.exports = {
 		REFRESH: "REFRESH"
 	},
 
-	EXPIRE_IN_MINUTES: 60
+	EXPIRE_IN_MINUTES: 60,
+
+	JOBS: {
+		CANCEL_CALLBACK: 'DEFINITIVE FAIL',
+	}
+
 };

--- a/models/CallbackTask.js
+++ b/models/CallbackTask.js
@@ -1,5 +1,5 @@
 const mongoose = require("mongoose");
-
+const { JOBS } = require("../constants/Constants");
 const CallbackTaskSchema = new mongoose.Schema({
 	status: {
 		type: String,
@@ -25,10 +25,24 @@ const CallbackTaskSchema = new mongoose.Schema({
 		type: Date,
 		default: new Date()
 	},
+	attempts: {
+		type: Number,
+		default: 0,
+	},
 	expireOn: String,
 	blockHash: String,
 	messageError: String
 });
+
+CallbackTaskSchema.methods.addAttempt = async function () {
+	
+	const update = this.attempts > 7 
+		? { $set: { status: JOBS.CANCEL_CALLBACK }}
+		: { $inc: { attempts:1 }
+	}
+	return this.update(update);
+
+};
 
 const CallbackTask = mongoose.model("CallbackTask", CallbackTaskSchema);
 module.exports = CallbackTask;

--- a/routes/IssuerRoutes.js
+++ b/routes/IssuerRoutes.js
@@ -275,6 +275,8 @@ router.post(
 	async function (req, res) {
 		const { did, name, callbackUrl, token } = req.body;
 		try {
+			const didExist = await IssuerService.getIssuerByDID(did);
+			if (didExist) throw Messages.ISSUER.ERR.DID_EXISTS;
 			const delegateTransaction = await IssuerService.createDelegateTransaction({
 				did,
 				name,


### PR DESCRIPTION
Como se describe en MM-160, los callbackTsask encolados que fallan no se eliminan, acumulándose con el tiempo. 

**Pruebas**
Inicialmente, se crean varias delegaciones y se encolan. Para generar los errores se utiliza siempre el mismo did. Se puede ver que la primera delegación se ejecutó correctamente y las siguientes fallaron
![MM-160-00](https://user-images.githubusercontent.com/5481398/112562862-0bb6e800-8db7-11eb-8999-61ea02537de9.png)

Estas tareas se encolan con un nuevo campo **attempts**, representando el total de intentos fallados ejecutando el callback.

![MM-160-01](https://user-images.githubusercontent.com/5481398/112562858-0b1e5180-8db7-11eb-9ef7-53efb5995005.png)

Por cada ejecución, este se incrementa en 1 hasta superar los 7 intentos.

![MM-160-02](https://user-images.githubusercontent.com/5481398/112562854-09ed2480-8db7-11eb-835b-95c57ce3c869.png)


Una vez superado el máximo de intentos, estos se descartan y no se intenta nuevamente.