### PR TITLE
Asegurar AppAuth service MM-316

### DIFF
--- a/__tests__/services/AppAuth.test.js
+++ b/__tests__/services/AppAuth.test.js
@@ -1,0 +1,31 @@
+const { findByDID, createApp } = require('../../services/AppAuthService');
+const {
+  missingDid, missingName, 
+} = require('../../constants/serviceErrors');
+
+describe('Should be green', () => {
+  test('Expect findByDID to throw on missing did', async () => {
+    try {
+      await findByDID(undefined);
+    } catch(e) {
+      expect(e.code).toMatch(missingDid.code);
+    }
+  });
+
+  test('Expect createApp to throw on missing did', async() => {
+    try {
+      await createApp(undefined, 'name');
+    } catch(e) {
+      expect(e.code).toMatch(missingDid.code);
+    }
+    
+  });
+
+  test('Expect createApp to throw on missing name', async () => {
+    try {
+      await createApp('did', undefined);
+    } catch(e) {
+      expect(e.code).toMatch(missingName.code);
+    }    
+  });
+});

--- a/constants/serviceErrors.js
+++ b/constants/serviceErrors.js
@@ -1,0 +1,10 @@
+module.exports = {
+  missingDid: {
+    code: "#service-missingDid",
+    message: `Falta el parámetro DID.`,
+  },
+  missingName: {
+    code: "#service-missingName",
+    message: `Falta el parámetro NAME.`,
+  }
+}

--- a/services/AppAuthService.js
+++ b/services/AppAuthService.js
@@ -1,12 +1,16 @@
 const AppAuth = require("../models/AppAuth");
 const {
-	VALIDATION: { APP_DID_NOT_FOUND }
+	VALIDATION: { APP_DID_NOT_FOUND },
 } = require("../constants/Messages");
+const {
+	missingName, missingDid,
+} = require("../constants/serviceErrors");
 
 /**
  *  Obtiene una aplicación autorizada por su did
  */
-const findByDID = async function (did) {
+const findByDID = async (did) => {
+	if(!did) throw missingDid;
 	const app = await AppAuth.getByDID(did);
 	if (!app) throw APP_DID_NOT_FOUND(did);
 	return app;
@@ -15,8 +19,10 @@ const findByDID = async function (did) {
 /**
  *  Crea una aplicación autorizada
  */
-const createApp = async function (did, name) {
-	return await AppAuth.create({ did, name });
+const createApp = async (did, name) => {
+	if(!did) throw missingDid;
+	if(!name) throw missingName;
+	return AppAuth.create({ did, name });
 };
 
 module.exports = {


### PR DESCRIPTION
- Lanzar error en cada parámetro ausente
- Nuevo archivo de errores par servicios
- Test unitarios por errores
- Remover await innecesario en return 

Tener en cuenta el formato para los siguientes pr