### PR TITLE
Fix/retry email verification

### DIFF
--- a/__tests__/controllers/mail/constants.js
+++ b/__tests__/controllers/mail/constants.js
@@ -1,0 +1,23 @@
+const email = 'test@test.io';
+const code = '123456';
+const did = 'did:ethr:0x31234E4CF6c075000024A954EC1D1B12bDcb1234';
+const req = {
+  body: {
+    eMail: email,
+  },
+};
+
+const res = {
+  type: jest.fn(),
+  // data: jest.fn(),
+  // end: jest.fn(),
+  json: jest.fn(),
+};
+
+module.exports = {
+  email,
+  req,
+  res,
+  code,
+  did,
+};

--- a/__tests__/controllers/mail/retryMailVerification.test.js
+++ b/__tests__/controllers/mail/retryMailVerification.test.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose');
+const { retryMailVerification } = require('../../../controllers/mail');
+const { create } = require('../../../services/MailService');
+const { MONGO_URL } = require('../../../constants/Constants');
+const Messages = require('../../../constants/Constants');
+const {
+  req, res, email, code, did,
+} = require('./constants');
+
+describe('controllers/mail/retryMailVerification.test.js', () => {
+  beforeAll(async () => {
+    await mongoose
+      .connect(MONGO_URL, {
+        useCreateIndex: true,
+        useFindAndModify: false,
+        useUnifiedTopology: true,
+        useNewUrlParser: true,
+      });
+    await create(email, code, did);
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.db.dropCollection('mails');
+    await mongoose.connection.close();
+  });
+
+  test.skip('Expect to throw if validation ism\'t created before', async () => {
+    try {
+      await retryMailVerification({ ...req, eMail: 'notVerified@test.io' }, res);
+    } catch (e) {
+      expect(e.code).toBe(Messages.EMAIL.ERR.NO_VALIDATIONS_FOR_EMAIL.code);
+      expect(e.message).toBe(Messages.EMAIL.ERR.NO_VALIDATIONS_FOR_EMAIL.message);
+    }
+  });
+
+  test('Expect to send validation new code', async () => {
+    await retryMailVerification(req, res);
+    expect(res.type.mock.calls.length).toBe(1);
+    expect(res.json.mock.calls.length).toBe(1);
+  });
+});

--- a/controllers/mail/retryMailVerification.js
+++ b/controllers/mail/retryMailVerification.js
@@ -1,13 +1,20 @@
-const ResponseHandler = require('../../utils/ResponseHandler');
 const MailService = require('../../services/MailService');
 const Messages = require('../../constants/Messages');
+const Constants = require('../../constants/Constants');
+const CodeGenerator = require('../../utils/CodeGenerator');
+const ResponseHandler = require('../../utils/ResponseHandler');
 
 const retryMailVerification = async (req, res) => {
   const eMail = req.body.eMail.toLowerCase();
   try {
-    const mail = await MailService.getByMail(eMail);
-    // Mandar mail con código de validación
-    await MailService.sendValidationCode(eMail, mail.code);
+    await MailService.getByMail(eMail);
+    const code = CodeGenerator.generateCode(Constants.RECOVERY_CODE_LENGTH);
+    if (Constants.DEBUGG) {
+      // eslint-disable-next-line no-console
+      console.log(code);
+    }
+    await MailService.create(eMail, code, undefined);
+    await MailService.sendValidationCode(eMail, code);
     return ResponseHandler.sendRes(res, Messages.EMAIL.SUCCESS.SENT);
   } catch (err) {
     return ResponseHandler.sendErr(res, err);


### PR DESCRIPTION
El código de verificación de email se guarda haseado, por lo que luego el enviarlo se enviaba el hash por email. Para soluciarlo se genera nuevamente el código.

![mail](https://user-images.githubusercontent.com/5481398/120708314-ca674680-c491-11eb-9c44-fabb311a5611.png)
