### PR TITLE
Fix services/UserAppService.createByTokens call to CertService.verifyCertificate

### DIFF
--- a/services/UserAppService.js
+++ b/services/UserAppService.js
@@ -59,6 +59,7 @@ const createByTokens = async function createByTokens(userToken, appToken) {
 
   const verified = await CertService.verifyCertificate(
     userToken,
+    undefined,
     Messages.ISSUER.ERR.CERT_IS_INVALID,
   );
   if (!verified.payload) throw INVALID_CODE(true);


### PR DESCRIPTION
CertService.verifyCertificate recibe 3 parámetros, en la invocación no se tenía en consideración el parámetro formal hash.