### PR TITLE
fix createCertificateByJwt 

### DIFF
--- a/controllers/issuer/createCertificateByJwt.js
+++ b/controllers/issuer/createCertificateByJwt.js
@@ -16,8 +16,7 @@ const createCertificateByJwt = async (req, res) => {
     // validar certificado y emisor (que este autorizado para emitir)
     console.log('Verifying JWT...');
     const cert = await CertService.verifyCertificate(jwt, undefined, Messages.ISSUER.ERR.IS_INVALID);
-    console.log('Cert: ');
-    console.log(cert);
+
     if (!cert || !cert.payload) return ResponseHandler.sendErr(res, Messages.ISSUER.ERR.CERT_IS_INVALID);
     // Validar si el emistor es correcto (autorizado a emitir y el mismo que el del certificado)
     console.log(`Verifying issuer ${cert.payload.iss}`);

--- a/controllers/issuer/createCertificateByJwt.js
+++ b/controllers/issuer/createCertificateByJwt.js
@@ -16,6 +16,8 @@ const createCertificateByJwt = async (req, res) => {
     // validar certificado y emisor (que este autorizado para emitir)
     console.log('Verifying JWT...');
     const cert = await CertService.verifyCertificate(jwt, undefined, Messages.ISSUER.ERR.IS_INVALID);
+    console.log('Cert: ');
+    console.log(cert);
     if (!cert || !cert.payload) return ResponseHandler.sendErr(res, Messages.ISSUER.ERR.CERT_IS_INVALID);
     // Validar si el emistor es correcto (autorizado a emitir y el mismo que el del certificado)
     console.log(`Verifying issuer ${cert.payload.iss}`);
@@ -58,7 +60,7 @@ const createCertificateByJwt = async (req, res) => {
         console.log(err);
       }
     }
-    return ResponseHandler.sendRes(res, result);
+    return ResponseHandler.sendRes(res, cert);
   } catch (err) {
     return ResponseHandler.sendErr(res, err);
   }


### PR DESCRIPTION
El endpoint estaba devolviendo una respuesta con el formato:
`{
  "status": "success",
  "data": {
    "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE2MjM0MzgwMTksInN1YiI6ImRpZDpldGhyOjB4YjgzZjlmOGJhNjI2MTdiY2QyZWM0ZGUwYTNkODExNTY5MmUwMzliNSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsiRW1haWwiOnsicHJldmlldyI6eyJ0eXBlIjowLCJmaWVsZHMiOlsiZW1haWwiXX0sImNhdGVnb3J5IjoiaWRlbnRpdHkiLCJkYXRhIjp7ImVtYWlsIjoiZnN1YXJlejkxQGdtYWlsLmNvbSJ9fX19LCJpc3MiOiJkaWQ6ZXRocjoweDc3NzRhMzNmMGEwYzgxMGNhMDc5NDA3NDI1YThmYjUwY2M0ZGRlMTQifQ.u1JO4mIW8S-ML4Nqamv6YbRAityIjGKmN9CghPY2sDHyE9UMEae78h8lkaeuqWlrdciPFvPADbJ7QogjWrnErAE",
    "hash": "5dad418538baa4a656e63463cd0162b6d751a566da75202479440711ef5553f27b3e416b879bdcf79b3e9dacb63d648aa9c95b879c23996c4fb3f1490fe34ca4"
  }
}`

Cuando deberia devolver algo como lo siguiente: 
`{
  "status": "success",
  "data": {
    "payload": {
      "iat": 1623438019,
      "sub": "did:ethr:0xb83f9f8ba62617bcd2ec4de0a3d8115692e039b5",
      "vc": {
        "@context": [
          "https://www.w3.org/2018/credentials/v1"
        ],
        "type": [
          "VerifiableCredential"
        ],
        "credentialSubject": {
          "Email": {
            "preview": {
              "type": 0,
              "fields": [
                "email"
              ]
            },
            "category": "identity",
            "data": {
              "email": "mail@mail.com"
            }
          }
        }
      },
      "iss": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14"
    },
    "doc": {
      "@context": "https://w3id.org/did/v1",
      "id": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14",
      "publicKey": [
        {
          "id": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14#owner",
          "type": "Secp256k1VerificationKey2018",
          "owner": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14",
          "ethereumAddress": "0x7774a33f0a0c810ca079407425a8fb50cc4dde14"
        },
      ],
      "authentication": [
        {
          "type": "Secp256k1SignatureAuthentication2018",
          "publicKey": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14#owner"
        },
      ]
    },
    "issuer": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14",
    "signer": {
      "id": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14#owner",
      "type": "Secp256k1VerificationKey2018",
      "owner": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14",
      "ethereumAddress": "0x7774a33f0a0c810ca079407425a8fb50cc4dde14"
    },
    "jwt": "token",
    "status": "UNVERIFIED"
  }
}`

Estaba respondiendo la devolución de mouro en lugar de la credencial en si.

Se modifico la respuesta para que devuelva la credencial.