### PR TITLE
fix: Ruta issuer/verifyCertificate 

### DIFF
--- a/controllers/issuer/index.js
+++ b/controllers/issuer/index.js
@@ -8,6 +8,7 @@ const { deleteDelegation } = require('./deleteDelegation');
 const { refreshDelegation } = require('./refreshDelegation');
 const { readIssuerNameByDid } = require('./readIssuerNameByDid');
 const { updateIssuerNameByDid } = require('./updateIssuerNameByDid');
+const { verifyCertificateByJwt } = require('./verifyCertificateByJwt');
 
 module.exports = {
   createCertificateByJwt,
@@ -20,4 +21,5 @@ module.exports = {
   refreshDelegation,
   readIssuerNameByDid,
   updateIssuerNameByDid,
+  verifyCertificateByJwt,
 };

--- a/controllers/issuer/verifyCertificateByJwt.js
+++ b/controllers/issuer/verifyCertificateByJwt.js
@@ -1,0 +1,38 @@
+/* eslint-disable max-len */
+/* eslint-disable no-console */
+const ResponseHandler = require('../../utils/ResponseHandler');
+const MouroService = require('../../services/MouroService');
+const CertService = require('../../services/CertService');
+const Messages = require('../../constants/Messages');
+const IssuerService = require('../../services/IssuerService');
+
+const verifyCertificateByJwt = async (req, res) => {
+  const { jwt } = req.body;
+  try {
+    // validar formato y desempaquetar
+    console.log('Verifying JWT...');
+    const decripted = await CertService.decodeCertificate(jwt, Messages.ISSUER.ERR.CERT_IS_INVALID);
+    const hash = await MouroService.isInMouro(jwt, decripted.payload.sub, Messages.ISSUER.ERR.NOT_FOUND);
+    const cert = await CertService.verifyCertificate(jwt, hash, Messages.ISSUER.ERR.CERT_IS_INVALID);
+    if (!cert || !cert.payload.vc) {
+      return ResponseHandler.sendRes(res, { cert, err: Messages.ISSUER.ERR.CERT_IS_INVALID });
+    }
+    console.log('JWT verified!');
+
+    console.log('Verifying Issuer...');
+    const did = cert.payload.iss;
+    await CertService.verifyIssuer(did);
+    const issuer = await IssuerService.getIssuerByDID(did);
+    if (!issuer) return ResponseHandler.sendErr(res, Messages.ISSUER.ERR.ISSUER_IS_INVALID);
+    console.log('Issuer verified!');
+    cert.issuer = issuer.name;
+    return ResponseHandler.sendRes(res, cert);
+  } catch (err) {
+    console.log(err);
+    return ResponseHandler.sendErr(res, err);
+  }
+};
+
+module.exports = {
+  verifyCertificateByJwt,
+};

--- a/routes/IssuerRoutes.js
+++ b/routes/IssuerRoutes.js
@@ -153,7 +153,7 @@ router.post(
   '/issuer/verifyCertificate',
   Validator.validateBody([{ name: 'jwt', validate: [Constants.VALIDATION_TYPES.IS_STRING] }]),
   halfHourLimiter,
-  issuer.createCertificateByJwt,
+  issuer.verifyCertificateByJwt,
 );
 
 /**


### PR DESCRIPTION
El endpoint estaba devolviendo una respuesta con el siguiente formato:
{ "status": "success", "data": { "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE2MjM0MzgwMTksInN1YiI6ImRpZDpldGhyOjB4YjgzZjlmOGJhNjI2MTdiY2QyZWM0ZGUwYTNkODExNTY5MmUwMzliNSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsiRW1haWwiOnsicHJldmlldyI6eyJ0eXBlIjowLCJmaWVsZHMiOlsiZW1haWwiXX0sImNhdGVnb3J5IjoiaWRlbnRpdHkiLCJkYXRhIjp7ImVtYWlsIjoiZnN1YXJlejkxQGdtYWlsLmNvbSJ9fX19LCJpc3MiOiJkaWQ6ZXRocjoweDc3NzRhMzNmMGEwYzgxMGNhMDc5NDA3NDI1YThmYjUwY2M0ZGRlMTQifQ.u1JO4mIW8S-ML4Nqamv6YbRAityIjGKmN9CghPY2sDHyE9UMEae78h8lkaeuqWlrdciPFvPADbJ7QogjWrnErAE", "hash": "5dad418538baa4a656e63463cd0162b6d751a566da75202479440711ef5553f27b3e416b879bdcf79b3e9dacb63d648aa9c95b879c23996c4fb3f1490fe34ca4" } }

Cuando debería devolver algo como lo siguiente:
{ "status": "success", "data": { "payload": { "iat": 1623438019, "sub": "did:ethr:0xb83f9f8ba62617bcd2ec4de0a3d8115692e039b5", "vc": { "@context": [ "https://www.w3.org/2018/credentials/v1" ], "type": [ "VerifiableCredential" ], "credentialSubject": { "Email": { "preview": { "type": 0, "fields": [ "email" ] }, "category": "identity", "data": { "email": "mail@mail.com" } } } }, "iss": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14" }, "doc": { "@context": "https://w3id.org/did/v1", "id": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14", "publicKey": [ { "id": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14#owner", "type": "Secp256k1VerificationKey2018", "owner": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14", "ethereumAddress": "0x7774a33f0a0c810ca079407425a8fb50cc4dde14" }, ], "authentication": [ { "type": "Secp256k1SignatureAuthentication2018", "publicKey": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14#owner" }, ] }, "issuer": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14", "signer": { "id": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14#owner", "type": "Secp256k1VerificationKey2018", "owner": "did:ethr:0x7774a33f0a0c810ca079407425a8fb50cc4dde14", "ethereumAddress": "0x7774a33f0a0c810ca079407425a8fb50cc4dde14" }, "jwt": "token", "status": "UNVERIFIED" } }

Estaba respondiendo la devolución de mouro en lugar de la credencial en si.

Esto sucedía porque al hacer refactor de la ruta, se llamo al mismo controlador desde dos rutas distintas.

Se agrego el controlador con la ruta correspondiente.