### PR TITLE
Fix validacion con Renaper

### DIFF
--- a/__tests__/services/Renaper.test.js
+++ b/__tests__/services/Renaper.test.js
@@ -15,7 +15,6 @@ const {
   missingFingerprintData,
   missingOperationId,
   missingFrontImage,
-  missingAnalyzeAnomalies,
   missingAnalyzeOcr,
   missingBackImage,
   missingSelfie,
@@ -107,14 +106,6 @@ describe('Should be green', () => {
     }
   });
 
-  test('Expect addFront to throw on missing analyzeAnomalies', async () => {
-    try {
-      await addFront('dni', 'gender', 'operationId', 'frontImage', undefined, 'analyzeOcr');
-    } catch (e) {
-      expect(e.code).toMatch(missingAnalyzeAnomalies.code);
-    }
-  });
-
   test('Expect addFront to throw on missing analyzeOcr', async () => {
     try {
       await addFront('dni', 'gender', 'operationId', 'frontImage', 'analyzeAnomalies', undefined);
@@ -155,14 +146,6 @@ describe('Should be green', () => {
       await addBack('dni', 'gender', 'operationId', undefined, 'analyzeAnomalies', 'analyzeOcr');
     } catch (e) {
       expect(e.code).toMatch(missingBackImage.code);
-    }
-  });
-
-  test('Expect addBack to throw on missing analyzeAnomalies', async () => {
-    try {
-      await addBack('dni', 'gender', 'operationId', 'backImage', undefined, 'analyzeOcr');
-    } catch (e) {
-      expect(e.code).toMatch(missingAnalyzeAnomalies.code);
     }
   });
 

--- a/constants/serviceErrors.js
+++ b/constants/serviceErrors.js
@@ -171,10 +171,6 @@ module.exports = {
     code: '#service-missingFrontImage',
     message: 'Falta el parámetro FRONTIMAGE',
   },
-  missingAnalyzeAnomalies: {
-    code: '#service-missingAnalyzeAnomalies',
-    message: 'Falta el parámetro ANALYZEANOMALIES',
-  },
   missingAnalyzeOcr: {
     code: '#service-missingAnalyzeOcr',
     message: 'Falta el parámetro ANALYZEOCR',

--- a/services/RenaperService.js
+++ b/services/RenaperService.js
@@ -9,7 +9,6 @@ const {
   missingFingerprintData,
   missingOperationId,
   missingFrontImage,
-  missingAnalyzeAnomalies,
   missingAnalyzeOcr,
   missingBackImage,
   missingSelfie,
@@ -96,7 +95,6 @@ module.exports.addFront = async function addFront(
   if (!gender) throw missingGender;
   if (!operationId) throw missingOperationId;
   if (!frontImage) throw missingFrontImage;
-  if (!analyzeAnomalies) throw missingAnalyzeAnomalies;
   if (!analyzeOcr) throw missingAnalyzeOcr;
   try {
     const result = await renaperPost(
@@ -126,7 +124,6 @@ module.exports.addBack = async function addBack(
   if (!gender) throw missingGender;
   if (!operationId) throw missingOperationId;
   if (!backImage) throw missingBackImage;
-  if (!analyzeAnomalies) throw missingAnalyzeAnomalies;
   if (!analyzeOcr) throw missingAnalyzeOcr;
   try {
     const result = await renaperPost(


### PR DESCRIPTION
En los servicios addFront y acabada se validaba si existía el parámetro analyzeNomalies. Este mismo es una constante definida como false en el archivo constants.js. Por lo tanto se remueve la validación en ambos servicios.