### PR TITLE
Obtener lista de issuers ordenada

### DIFF
--- a/controllers/issuer/readIssuerByDid.js
+++ b/controllers/issuer/readIssuerByDid.js
@@ -9,7 +9,6 @@ const readIssuerByDid = async (req, res) => {
   try {
     const issuer = await IssuerService.getIssuerByDID(did);
     if (!issuer) return ResponseHandler.sendErr(res, Messages.ISSUER.ERR.IS_INVALID);
-    console.log(issuer);
     const {
       name, description, imageId, expireOn,
     } = issuer;

--- a/models/Issuer.js
+++ b/models/Issuer.js
@@ -107,6 +107,10 @@ Issuer.getAll = async function getAll(limit, page) {
   {
     did: 1, name: 1, description: 1, imageId: 1,
   })
+    .collation({
+      locale: 'es',
+      caseFirst: 'off',
+    })
     .sort({ name: 1 })
     .skip(page > 0 ? ((page - 1) * limit) : 0)
     .limit(limit);

--- a/services/IssuerService.js
+++ b/services/IssuerService.js
@@ -46,11 +46,8 @@ module.exports.addIssuer = async function addIssuer(did, name, description) {
     expireOn.setSeconds(expireOn.getSeconds() + Number(Constants.BLOCKCHAIN.DELEGATE_DURATION));
   }
 
-  // Capitalizar primer letra del nombre
-  const normalizedName = name.charAt(0).toUpperCase() + name.slice(1);
-
   return Issuer.create({
-    name: normalizedName, did, expireOn, blockHash: 'transactionHash', description,
+    name, did, expireOn, blockHash: transactionHash, description,
   });
 };
 


### PR DESCRIPTION
- Se actualiza la consulta a mongodb, para que al ordenar el listado de issuers no se tomen en cuenta las mayúsculas y minúsculas.
- Se elimina la normalización del nombre al guardar un issuer en la db
- Arreglos varios