### PR TITLE
MM-448 Nuevo endpoint /issuer/:did/image

### DIFF
--- a/__tests__/services/Blockchain/utils.js
+++ b/__tests__/services/Blockchain/utils.js
@@ -9,8 +9,8 @@ const addIssuers = async () => {
   const bfa = Credentials.createIdentity();
   bfa.did = `did:ethr:bfa:${bfa.did}`;
 
-  await addIssuer(rsk.did, `Test: ${rsk.did}`);
-  await addIssuer(lacchain.did, `Test: ${lacchain.did}`);
+  await addIssuer(rsk.did, `Test: ${rsk.did}`, 'Issuer description');
+  await addIssuer(lacchain.did, `Test: ${lacchain.did}`, 'Issuer description');
   // await addIssuer(bfa.did, `Test: ${bfa.did}`);
   return { rsk, lacchain, bfa };
 };

--- a/controllers/issuer/index.js
+++ b/controllers/issuer/index.js
@@ -10,7 +10,7 @@ const { readIssuerByDid } = require('./readIssuerByDid');
 const { updateIssuerByDid } = require('./updateIssuerByDid');
 const { verifyCertificateByJwt } = require('./verifyCertificateByJwt');
 const { readAllIssuers } = require('./readAllIssuers');
-const { readIssuerImageByDid } = require('./readIssuerImageByDid');
+const { readIssuerImagesByDid } = require('./readIssuerImagesByDid');
 
 module.exports = {
   createCertificateByJwt,
@@ -25,5 +25,5 @@ module.exports = {
   updateIssuerByDid,
   verifyCertificateByJwt,
   readAllIssuers,
-  readIssuerImageByDid,
+  readIssuerImagesByDid,
 };

--- a/controllers/issuer/index.js
+++ b/controllers/issuer/index.js
@@ -10,6 +10,7 @@ const { readIssuerByDid } = require('./readIssuerByDid');
 const { updateIssuerByDid } = require('./updateIssuerByDid');
 const { verifyCertificateByJwt } = require('./verifyCertificateByJwt');
 const { readAllIssuers } = require('./readAllIssuers');
+const { readIssuerImageByDid } = require('./readIssuerImageByDid');
 
 module.exports = {
   createCertificateByJwt,
@@ -24,4 +25,5 @@ module.exports = {
   updateIssuerByDid,
   verifyCertificateByJwt,
   readAllIssuers,
+  readIssuerImageByDid,
 };

--- a/controllers/issuer/readIssuerImageByDid.js
+++ b/controllers/issuer/readIssuerImageByDid.js
@@ -1,27 +1,22 @@
-const ResponseHandler = require('../../utils/ResponseHandler');
 const IssuerService = require('../../services/IssuerService');
 const Messages = require('../../constants/Messages');
+const ResponseHandler = require('../../utils/ResponseHandler');
 
-const readIssuerByDid = async (req, res) => {
+const readIssuerImageByDid = async (req, res) => {
   const { did } = req.params;
 
   try {
     const issuer = await IssuerService.getIssuerByDID(did);
     if (!issuer) return ResponseHandler.sendErr(res, Messages.ISSUER.ERR.IS_INVALID);
-    const {
-      name, description, imageId, expireOn, imageUrl,
-    } = issuer;
 
-    const issuerData = {
-      name, description, imageUrl, imageId, did, expireOn,
-    };
+    const { imageUrl } = issuer;
 
-    return ResponseHandler.sendRes(res, issuerData);
+    return ResponseHandler.sendRes(res, [imageUrl]);
   } catch (err) {
     return ResponseHandler.sendErr(res, err);
   }
 };
 
 module.exports = {
-  readIssuerByDid,
+  readIssuerImageByDid,
 };

--- a/controllers/issuer/readIssuerImagesByDid.js
+++ b/controllers/issuer/readIssuerImagesByDid.js
@@ -9,9 +9,9 @@ const readIssuerImagesByDid = async (req, res) => {
     const issuer = await IssuerService.getIssuerByDID(did);
     if (!issuer) return ResponseHandler.sendErr(res, Messages.ISSUER.ERR.IS_INVALID);
 
-    const { imageUrl } = issuer;
+    const { imageUrl, imageId } = issuer;
 
-    return ResponseHandler.sendRes(res, [imageUrl]);
+    return ResponseHandler.sendRes(res, [imageUrl, imageId]);
   } catch (err) {
     return ResponseHandler.sendErr(res, err);
   }

--- a/controllers/issuer/readIssuerImagesByDid.js
+++ b/controllers/issuer/readIssuerImagesByDid.js
@@ -2,7 +2,7 @@ const IssuerService = require('../../services/IssuerService');
 const Messages = require('../../constants/Messages');
 const ResponseHandler = require('../../utils/ResponseHandler');
 
-const readIssuerImageByDid = async (req, res) => {
+const readIssuerImagesByDid = async (req, res) => {
   const { did } = req.params;
 
   try {
@@ -18,5 +18,5 @@ const readIssuerImageByDid = async (req, res) => {
 };
 
 module.exports = {
-  readIssuerImageByDid,
+  readIssuerImagesByDid,
 };

--- a/routes/IssuerRoutes.js
+++ b/routes/IssuerRoutes.js
@@ -384,7 +384,7 @@ router.get('/issuer/:did', issuer.readIssuerByDid);
  *       500:
  *         description: Error interno del servidor
  */
-router.get('/issuer/:did/image', issuer.readIssuerImageByDid);
+router.get('/issuer/:did/image', issuer.readIssuerImagesByDid);
 
 /**
  * @openapi

--- a/routes/IssuerRoutes.js
+++ b/routes/IssuerRoutes.js
@@ -367,6 +367,27 @@ router.get('/issuer/:did', issuer.readIssuerByDid);
 
 /**
  * @openapi
+ *   /issuer/{did}/image:
+ *   get:
+ *     summary: Obtiene la imagen de un emisor autorizado a partir de su did.
+ *     parameters:
+ *       - name: did
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type : string
+ *     responses:
+ *       200:
+ *         description: Puede devolver ok o error en algun parametro
+ *       401:
+ *         description: Acción no autorizada
+ *       500:
+ *         description: Error interno del servidor
+ */
+router.get('/issuer/:did/image', issuer.readIssuerImageByDid);
+
+/**
+ * @openapi
  *   /issuer/{did}:
  *   patch:
  *     summary: Modifica la informacion de un emisor autorizadod.


### PR DESCRIPTION
- Se agrega la nueva ruta /issuer/:did/image a Issuer Routes, que devuelve la url de la imagen de un issuer según su Did.
- Se elimina del controlador readIssuerByDid un llamado innecesario a la función getImageUrl.