### PR TITLE
[VUS-259] Arrego del servicio getIssuerByDID

### DIFF
--- a/__tests__/services/Issuer/constatns.js
+++ b/__tests__/services/Issuer/constatns.js
@@ -7,6 +7,7 @@ const serverDid = `did:ethr:${SERVER_DID}`;
 const data = {
   allNetworksDid: 'did:ethr:0xd98cdaac3f682ca2fb72fbad3090a22462290037',
   did: 'did:ethr:lacchain:0x36f6dc06d34b164aec5421c9071a0d07765d4ee1',
+  didWithoutNet: 'did:ethr:0x36f6dc06d34b164aec5421c9071a0d07765d4ee1',
   lacchainDid: 'did:ethr:rsk:0x36f6dc06d34b164aec5421c9071a0d07765d4ee0',
   rskDid: 'did:ethr:rsk:0x36f6dc06d34b164aec5421c9071a0d07765d4ee0',
   key: '08c5c2d853de11b8a31da6048433f35d3ea966dd9dd558172ef2606a569eec03',

--- a/__tests__/services/Issuer/getIssuerByDID.test.js
+++ b/__tests__/services/Issuer/getIssuerByDID.test.js
@@ -8,7 +8,7 @@ const Messages = require('../../../constants/Messages');
 
 describe('services/Issuer/getIssuerByDID.test.js', () => {
   const {
-    did, name, secondDid, description,
+    did, name, secondDid, description, didWithoutNet,
   } = data;
   beforeAll(async () => {
     await mongoose
@@ -34,9 +34,14 @@ describe('services/Issuer/getIssuerByDID.test.js', () => {
       }
     });
 
-    test('Expect getIssuerByDID to success', async () => {
+    test('Expect getIssuerByDID to success - did with net', async () => {
       const response = await getIssuerByDID(did);
-      expect(response.did).toBe(did);
+      expect(response.did).toBe(didWithoutNet);
+    });
+
+    test('Expect getIssuerByDID to success - did without net', async () => {
+      const response = await getIssuerByDID(didWithoutNet);
+      expect(response.did).toBe(didWithoutNet);
     });
 
     test('Expect getIssuerByDID to throw error on invalid did', async () => {

--- a/__tests__/services/Issuer/getIssuerByDID.test.js
+++ b/__tests__/services/Issuer/getIssuerByDID.test.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const { MONGO_URL } = require('../../../constants/Constants');
 const { getIssuerByDID, addIssuer } = require('../../../services/IssuerService');
 const { missingDid } = require('../../../constants/serviceErrors');
-const { revokeDelegate, removeBlockchainFromDid } = require('../../../services/BlockchainService');
+const { revokeDelegate } = require('../../../services/BlockchainService');
 const { data } = require('./constatns');
 const Messages = require('../../../constants/Messages');
 
@@ -35,9 +35,8 @@ describe('services/Issuer/getIssuerByDID.test.js', () => {
     });
 
     test('Expect getIssuerByDID to success', async () => {
-      const didWithoutNetwork = await removeBlockchainFromDid(did);
-      const response = await getIssuerByDID(didWithoutNetwork);
-      expect(response.did).toBe(didWithoutNetwork);
+      const response = await getIssuerByDID(did);
+      expect(response.did).toBe(did);
     });
 
     test('Expect getIssuerByDID to throw error on invalid did', async () => {

--- a/services/IssuerService.js
+++ b/services/IssuerService.js
@@ -134,7 +134,8 @@ module.exports.refresh = async function refresh(did) {
 module.exports.getIssuerByDID = async function getIssuerByDID(did) {
   if (!did) throw missingDid;
   try {
-    return await Issuer.getByDID(did);
+    const didWithoutNetwork = await BlockchainService.removeBlockchainFromDid(did);
+    return await Issuer.getByDID(didWithoutNetwork);
   } catch (err) {
     console.log(err);
     throw err;


### PR DESCRIPTION
- Se agrega método e la librería BlockchainManager removeBlockchainFromDid en el servicio getIssuerByDID para que en el momento de buscar emisores en la base de datos obtenga un resultado ya sea si el did tiene la red o como si no.